### PR TITLE
chore: move tailwind theme config into tailwind config

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -5,39 +5,7 @@ layer(base);
 layer(base);
 
 @import 'tailwindcss';
-
-@theme {
-    --font-gotu: Gotu;
-    --font-quattrocento: Quattrocento;
-    --font-poppins: Poppins;
-
-    --text-2xs: 10px;
-    --text-2xs--line-height: 17px;
-    --text-xs: 12px;
-    --text-xs--line-height: 20px;
-    --text-sm: 14px;
-    --text-sm--line-height: 23px;
-    --text-base: 16px;
-    --text-base--line-height: 27px;
-    --text-lg: 18px;
-    --text-lg--line-height: 30px;
-    --text-xl: 20px;
-    --text-xl--line-height: 33px;
-    --text-2xl: 22px;
-    --text-2xl--line-height: 37px;
-    --text-3xl: 1.953rem;
-    --text-4xl: 2.441rem;
-    --text-5xl: 3.052rem;
-
-    --color-primary: #d3a528;
-    --color-snow: #fffdfa;
-
-    --color-shade-0: white;
-    --color-shade-100: #333333;
-
-    --color-timeline-node: #d6d5d3;
-    --color-timeline-year: #b1b1b1;
-}
+@config "../../tailwind.config.js";
 
 @layer base {
     *,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,38 @@
+module.exports = {
+    content: ['./src/**/*.{ts,tsx,svg}'],
+    darkMode: ['class'],
+    theme: {
+        extend: {
+            fontFamily: {
+                gotu: 'Gotu',
+                quattrocento: 'Quattrocento',
+                poppins: 'Poppins',
+            },
+            fontSize: {
+                '2xs': ['10px', '17px'],
+                xs: ['12px', '20px'],
+                sm: ['14px', '23px'],
+                base: ['16px', '27px'],
+                lg: ['18px', '30px'],
+                xl: ['20px', '33px'],
+                '2xl': ['22px', '37px'],
+                '3xl': '1.953rem',
+                '4xl': '2.441rem',
+                '5xl': '3.052rem',
+            },
+            colors: {
+                primary: '#D3A528',
+                snow: '#FFFDFA',
+                shade: {
+                    0: 'white',
+                    100: '#333333',
+                },
+                timeline: {
+                    node: '#D6D5D3',
+                    year: '#B1B1B1',
+                },
+            },
+        },
+    },
+    plugins: [],
+};


### PR DESCRIPTION
This pull request updates the global styles by removing custom CSS variables and replacing them with a reference to the Tailwind CSS configuration file. This change simplifies the styling approach by consolidating configuration into the Tailwind framework.

### Simplification of global styles:
* [`src/styles/globals.css`](diffhunk://#diff-dd438e7ca4da8a47a35709920a07b6fef918609c1daa40f6e9b794ddfd3e4996L8-R8): Removed custom CSS variables (e.g., `--font-gotu`, `--text-2xs`, `--color-primary`) and replaced the `@theme` block with a reference to the Tailwind configuration file (`@config "../../tailwind.config.js"`).