### PR TITLE
feat: update section scroll offset

### DIFF
--- a/src/common/constants/default.ts
+++ b/src/common/constants/default.ts
@@ -10,4 +10,5 @@ export const defaultValue = {
     tewntyScoops: 'https://20scoopscnx.com',
     blueBik: 'https://bluebik.com',
     xplore: 'https://www.xplore.in.th/th',
+    navbarOffset: 62,
 };

--- a/src/common/hooks/web-scroller.ts
+++ b/src/common/hooks/web-scroller.ts
@@ -1,10 +1,11 @@
+import { defaultValue } from 'common/constants/default';
 import { ForwardedRef } from 'react';
 
 export const useWebScroller = () => {
     const handleWebScroll = (ref?: ForwardedRef<HTMLDivElement>) => {
         let top = 0;
         if (ref && typeof ref !== 'function' && 'current' in ref && ref.current) {
-            top = ref.current.offsetTop;
+            top = ref.current.offsetTop - defaultValue.navbarOffset;
         }
         window.scrollTo({
             top,

--- a/src/common/layout/index.tsx
+++ b/src/common/layout/index.tsx
@@ -1,5 +1,6 @@
 import Navbar from './navbar';
 import Footer from './footer';
+import { defaultValue } from 'common/constants/default';
 
 type AppLayoutProps = {
     children: React.ReactNode;
@@ -9,7 +10,11 @@ const AppLayout = ({ children }: AppLayoutProps) => {
     return (
         <div className="flex flex-col h-full min-h-screen">
             <Navbar />
-            <div className="flex flex-col w-full flex-1 translate-y-[-62px]">{children}</div>
+            <div
+                className={`flex flex-col w-full flex-1 translate-y-[-${defaultValue.navbarOffset}px]`}
+            >
+                {children}
+            </div>
             <Footer />
         </div>
     );


### PR DESCRIPTION
This pull request introduces a new constant, `navbarOffset`, in the `defaultValue` object and refactors its usage across the codebase to improve maintainability and consistency. The changes primarily focus on replacing hardcoded values with the new constant.

### Introduction of `navbarOffset` constant:
* [`src/common/constants/default.ts`](diffhunk://#diff-a16f662f79cd4d2cf693631ea7b8b08e948ffb60f7acff69920509b791efba45R13): Added `navbarOffset` with a value of `62` to the `defaultValue` object.

### Refactoring to use `navbarOffset`:
* [`src/common/hooks/web-scroller.ts`](diffhunk://#diff-c4c0b94472675bb50b26e7bc1fcf36a0fdc88c5e770e229e2727751db1a056a1R1-R8): Updated the `useWebScroller` hook to calculate the scroll position dynamically using `defaultValue.navbarOffset` instead of a hardcoded value.
* [`src/common/layout/index.tsx`](diffhunk://#diff-b555641c453395263e8fc92ce1c633b5b6a1f60dd8944673916bb927b0c05db0R3): Refactored the `AppLayout` component to use `defaultValue.navbarOffset` for the `translate-y` CSS property, replacing the hardcoded value of `62px`. [[1]](diffhunk://#diff-b555641c453395263e8fc92ce1c633b5b6a1f60dd8944673916bb927b0c05db0R3) [[2]](diffhunk://#diff-b555641c453395263e8fc92ce1c633b5b6a1f60dd8944673916bb927b0c05db0L12-R17)