### PR TITLE
chore: update hero and me section messages

### DIFF
--- a/src/common/constants/site-content.ts
+++ b/src/common/constants/site-content.ts
@@ -4,5 +4,13 @@ const currentYear = new Date().getFullYear();
 
 export const SITE_CONTENT = {
     title: TITLE,
+    hero: {
+        title: 'Build things people love,\nfor web & app.',
+        subTitle: `I'm Pongpanot, a software engineer. Interested in learning more about me? Let’s follow the sign.`,
+    },
+    me: {
+        title: 'me? Always coding.',
+        description: `Hello again! I’m Pongpanot, a software engineer specializing in frontend and mobile development, based in Chiang Mai. Focused on creating digital experiences that seamlessly blend visual appeal and high functionality, from the initial concept all the way through to launch.`,
+    },
     footer: `Designed & Developed by ${TITLE} ${currentYear}`,
 };

--- a/src/common/constants/static-text/home.ts
+++ b/src/common/constants/static-text/home.ts
@@ -1,4 +1,0 @@
-export const HomePageStaticText = {
-    heroTitle: 'Build things people love,\nfor web & app',
-    heroMessage: `I'm Pongpanot, a frontend develop. Interested in learning more about me? let’s follow the sign.`,
-};

--- a/src/container/home-page/sections/hero-section/index.tsx
+++ b/src/container/home-page/sections/hero-section/index.tsx
@@ -3,11 +3,11 @@ import Icon from 'common/base-ui/icon';
 import HeaderText from 'common/base-ui/text/header-text';
 import { useMediaSize } from 'common/hooks/media-size';
 import { AppIconEnum } from 'common/base-ui/icon/viewmodel';
-import { HomePageStaticText } from 'common/constants/static-text/home';
 import HeroSectionFooter from './hero-section-footer';
 import { forwardRef } from 'react';
 import { useWebScroller } from 'common/hooks/web-scroller';
 import FullScreenSectionContainer from 'common/base-ui/layout/full-screen-section-container';
+import { SITE_CONTENT } from 'common/constants';
 
 const HeroSection = forwardRef<HTMLDivElement, unknown>((_, ref) => {
     const { isMobile } = useMediaSize();
@@ -17,13 +17,13 @@ const HeroSection = forwardRef<HTMLDivElement, unknown>((_, ref) => {
         <FullScreenSectionContainer className="relative" ref={ref}>
             <div className="my-auto text-center">
                 <HeaderText
-                    message={HomePageStaticText.heroTitle}
+                    message={SITE_CONTENT.hero.title}
                     fontSize={isMobile ? 48 : 66}
-                    className="mb-[18px] md:mb-6"
+                    className="mb-[18px] md:mb-6 md:whitespace-pre-line"
                 />
 
                 <p className="text-sm md:text-base max-w-[463px] lg:text-lg w-full mx-auto whitespace-pre-line">
-                    {HomePageStaticText.heroMessage}
+                    {SITE_CONTENT.hero.subTitle}
                 </p>
 
                 <CircleButton

--- a/src/container/home-page/sections/me-section/index.tsx
+++ b/src/container/home-page/sections/me-section/index.tsx
@@ -4,8 +4,8 @@ import Icon from 'common/base-ui/icon';
 import { AppIconEnum } from 'common/base-ui/icon/viewmodel';
 import SectionContainer from 'common/base-ui/layout/section-container';
 import HeaderText from 'common/base-ui/text/header-text';
-import { meStaticText } from 'common/constants/static-text/me';
 import { useMediaSize } from 'common/hooks/media-size';
+import { SITE_CONTENT } from 'common/constants';
 
 const MeSection = forwardRef<HTMLDivElement>((_, ref) => {
     const { isMobile, isTablet, isDesktop } = useMediaSize();
@@ -27,11 +27,11 @@ const MeSection = forwardRef<HTMLDivElement>((_, ref) => {
                     />
                     <div>
                         <HeaderText
-                            message={meStaticText.meTitle}
+                            message={SITE_CONTENT.me.title}
                             fontSize={isMobile ? 40 : isTablet ? 48 : 52}
                             className="mb-[18px] md:mb-5 xl:mb-6"
                         />
-                        <p className="text-sm md:text-base">{meStaticText.meMessage}</p>
+                        <p className="text-sm md:text-base">{SITE_CONTENT.me.description}</p>
                     </div>
                 </div>
             </SectionContainer>


### PR DESCRIPTION
This pull request refactors the way static text content is managed by consolidating it into a single `SITE_CONTENT` object. It removes redundant static text files and updates the relevant components to use the new centralized structure. This change simplifies the codebase and makes it easier to maintain and update static content.

### Centralization of Static Text Content:

* Added a new `SITE_CONTENT` object in `src/common/constants/site-content.ts` to centralize static text, including hero section and "me" section content.
* Removed the `HomePageStaticText` object from `src/common/constants/static-text/home.ts`, as its content is now part of `SITE_CONTENT`.

### Updates to Hero Section:

* Updated the hero section in `src/container/home-page/sections/hero-section/index.tsx` to use `SITE_CONTENT.hero.title` and `SITE_CONTENT.hero.subTitle` instead of the removed `HomePageStaticText` object. [[1]](diffhunk://#diff-0f0f5c35404e2541ff5f09496d487156db4a841cc0dd245e0e244388f6437338L6-R10) [[2]](diffhunk://#diff-0f0f5c35404e2541ff5f09496d487156db4a841cc0dd245e0e244388f6437338L20-R26)

### Updates to "Me" Section:

* Updated the "me" section in `src/container/home-page/sections/me-section/index.tsx` to use `SITE_CONTENT.me.title` and `SITE_CONTENT.me.description` instead of the removed `meStaticText` object. [[1]](diffhunk://#diff-7b8573eff961836a61c372fb0a12d29b1dd94df3842a0eb4d93944dd9864ef30L7-R8) [[2]](diffhunk://#diff-7b8573eff961836a61c372fb0a12d29b1dd94df3842a0eb4d93944dd9864ef30L30-R34)