### PR TITLE
feat: adjust journey section content size

### DIFF
--- a/src/common/base-ui/text/header-text/index.tsx
+++ b/src/common/base-ui/text/header-text/index.tsx
@@ -15,6 +15,7 @@ const fontSizeMapping: Record<string, string> = {
     66: 'text-[66px] leading-[73px]',
 };
 
+/** @deprecated */
 const HeaderText = ({ className, message, fontSize = 48 }: HeaderTextProps) => {
     return (
         <p className={cx(className, 'font-quattrocento', fontSizeMapping[fontSize])}>{message}</p>

--- a/src/common/constants/site-content.ts
+++ b/src/common/constants/site-content.ts
@@ -12,5 +12,8 @@ export const SITE_CONTENT = {
         title: 'me? Always coding.',
         description: `Hello again! I’m Pongpanot, a software engineer specializing in frontend and mobile development, based in Chiang Mai. Focused on creating digital experiences that seamlessly blend visual appeal and high functionality, from the initial concept all the way through to launch.`,
     },
+    journey: {
+        title: 'Previous stops on my journey.',
+    },
     footer: `Designed & Developed by ${TITLE} ${currentYear}`,
 };

--- a/src/container/home-page/sections/journey-section/components/journey.tsx
+++ b/src/container/home-page/sections/journey-section/components/journey.tsx
@@ -14,7 +14,7 @@ const Journey = ({ className, journey }: JourneyProps) => {
     return journey.position ? (
         <div className={className}>
             <div className="mb-4">
-                <p className="text-sm mb-1 md:text-base">
+                <p className="mb-1">
                     {journey.position}
                     <Link
                         href={journey?.link}

--- a/src/container/home-page/sections/journey-section/index.tsx
+++ b/src/container/home-page/sections/journey-section/index.tsx
@@ -4,19 +4,16 @@ import { useMediaSize } from 'common/hooks/media-size';
 import MobileJourney from './components/mobile-journey';
 import TabletJourney from './components/tablet-journey';
 import SectionContainer from 'common/base-ui/layout/section-container';
+import { SITE_CONTENT } from 'common/constants';
 
 const JourneySection = () => {
     const { isMobile } = useMediaSize();
 
     return (
         <SectionContainer>
-            <HeaderText
-                message={meStaticText.journeyTitle}
-                fontSize={isMobile ? 30 : 36}
-                className="mb-6 md:text-center md:mb-12"
-            />
+            <h3 className="mb-[18px] md:text-center md:mb-12">{SITE_CONTENT.journey.title}</h3>
             <MobileJourney />
-            <TabletJourney />
+            {/* <TabletJourney /> */}
         </SectionContainer>
     );
 };

--- a/src/container/home-page/sections/me-section/index.tsx
+++ b/src/container/home-page/sections/me-section/index.tsx
@@ -26,12 +26,10 @@ const MeSection = forwardRef<HTMLDivElement>((_, ref) => {
                         )}
                     />
                     <div>
-                        <HeaderText
-                            message={SITE_CONTENT.me.title}
-                            fontSize={isMobile ? 40 : isTablet ? 48 : 52}
-                            className="mb-[18px] md:mb-5 xl:mb-6"
-                        />
-                        <p className="text-sm md:text-base">{SITE_CONTENT.me.description}</p>
+                        <h2 className="mb-[18px] md:mb-5 lg:mb-6">{SITE_CONTENT.me.title}</h2>
+                        <p className="text-sm md:text-base max-w-[500px] mx-auto md:max-w-none">
+                            {SITE_CONTENT.me.description}
+                        </p>
                     </div>
                 </div>
             </SectionContainer>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -21,6 +21,15 @@ layer(base);
     h1 {
         @apply font-quattrocento text-6xl md:text-7xl lg:text-8xl;
     }
+    h2 {
+        @apply font-quattrocento text-4xl md:text-5xl lg:text-6xl;
+    }
+    h3 {
+        @apply font-quattrocento text-3xl md:text-4xl;
+    }
+    p {
+        @apply font-gotu text-base lg:text-lg;
+    }
 }
 
 html,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,7 +16,7 @@ module.exports = {
                 lg: '18px',
                 xl: '20px',
                 '2xl': '22px',
-                '3xl': '30pxs',
+                '3xl': '30px',
                 '4xl': '36px',
                 '5xl': '40px',
                 '6xl': '48px',


### PR DESCRIPTION
This pull request introduces several updates to improve the consistency and maintainability of typography and content structure across the codebase. Key changes include deprecating the `HeaderText` component, centralizing content in `SITE_CONTENT`, and standardizing typography styles for headings and paragraphs.

### Typography and Component Updates:
* Deprecated the `HeaderText` component by marking it with a `/** @deprecated */` comment in `src/common/base-ui/text/header-text/index.tsx` to encourage the use of semantic HTML elements like `<h2>` and `<h3>` instead.
* Updated global typography styles in `src/styles/globals.css` to define consistent styles for `<h2>`, `<h3>`, and `<p>` elements using TailwindCSS utility classes.

### Content Centralization:
* Added a `journey` key to `SITE_CONTENT` in `src/common/constants/site-content.ts` to centralize and manage static text for the "Journey" section.

### Component Refactoring:
* Replaced the `HeaderText` component with an `<h3>` element in `JourneySection` and updated its content to use `SITE_CONTENT.journey.title`. Commented out the `TabletJourney` component for potential future use.
* Replaced the `HeaderText` component with an `<h2>` element in `MeSection` and adjusted the paragraph content for better alignment and readability.

### Minor Adjustments:
* Removed unnecessary `text-sm` class from a `<p>` element in `Journey` to simplify styling.