### PR TITLE
feat: updates contact links to use telephone number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pongpanott.github.io",
-    "version": "0.1.0",
+    "version": "1.1.0",
     "private": true,
     "scripts": {
         "dev": "next dev",

--- a/src/common/base-ui/work-card/commision/index.tsx
+++ b/src/common/base-ui/work-card/commision/index.tsx
@@ -27,10 +27,10 @@ const CommissionCard = ({ className }: CommissionCardProps) => {
                     {SITE_CONTENT.work.commission.description}
                 </p>
                 <Link
-                    href={`mailto:${EXTERNAL_LINK.contact.email}`}
+                    href={`tel:${EXTERNAL_LINK.contact.tel}`}
                     className="w-fit mx-auto flex items-center gap-x-2"
                 >
-                    <span className="text-base">Get in touch</span>
+                    <span className="text-base">Drop a Line</span>
                     <Icon icon={AppIconEnum.ARROW_RIGHT} iconSize={16} />
                 </Link>
             </div>

--- a/src/common/constants/external-link.ts
+++ b/src/common/constants/external-link.ts
@@ -3,6 +3,7 @@ export const EXTERNAL_LINK = {
         email: 'plurm.pongpanot@gmail.com',
         github: 'https://github.com/pongpanott',
         linkedIn: 'https://www.linkedin.com/in/pongpanot-tunkrongsin-b61449139/',
+        tel: '+66840454666',
     },
     cmu: 'https://www.cmu.ac.th',
     getnuvo: 'https://www.getnuvo.com',

--- a/src/common/layout/navbar/components/navbar-items.tsx
+++ b/src/common/layout/navbar/components/navbar-items.tsx
@@ -35,11 +35,11 @@ const NavbarItems = ({ setIsOpen }: { setIsOpen: (value: boolean) => void }) => 
                 href={HashRouteEnum.ME}
             />
             <NavbarItem
-                label="get in touch."
+                label="drop a line."
                 onClick={() => {
                     setIsOpen(false);
                 }}
-                href={`mailto:${EXTERNAL_LINK.contact.email}`}
+                href={`tel:${EXTERNAL_LINK.contact.tel}`}
             />
         </div>
     );


### PR DESCRIPTION
This pull request includes updates to improve the contact functionality across the application and updates the version in `package.json`. The most important changes involve replacing email-based contact links with phone-based contact links and updating corresponding labels.

### Contact functionality updates:

* [`src/common/base-ui/work-card/commision/index.tsx`](diffhunk://#diff-2eb6d5d1acac0a1094d136cb42d6074fc0d5e5b2196b200a61c06522665818d1L30-R33): Changed the contact link from an email (`mailto`) to a phone number (`tel`) and updated the label from "Get in touch" to "Drop a Line."
* [`src/common/constants/external-link.ts`](diffhunk://#diff-e69adba255e4524f50fa854d3721813e29894615f8e1861e77eaf9662a8f0985R6): Added a new `tel` field with the phone number `+66840454666` to the `EXTERNAL_LINK` object.
* [`src/common/layout/navbar/components/navbar-items.tsx`](diffhunk://#diff-eabf7ba575952db7f8fd41d65fdb3f427871c9f0bfea125d125e1b24811c497aL38-R42): Updated the contact link in the navbar from an email (`mailto`) to a phone number (`tel`) and changed the label from "get in touch." to "drop a line."

### Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `0.1.0` to `1.1.0` to reflect the new changes.