### PR TITLE
chore: update deployment github actions workflow

### DIFF
--- a/.github/workflows/next-js.yml
+++ b/.github/workflows/next-js.yml
@@ -77,7 +77,7 @@ jobs:
             - name: Static HTML export with Next.js
               run: ${{ steps.detect-package-manager.outputs.runner }} next export
             - name: Upload artifact
-              uses: actions/upload-pages-artifact@v2
+              uses: actions/upload-pages-artifact@v3
               with:
                   path: ./out
 


### PR DESCRIPTION
This pull request includes an update to the GitHub Actions workflow for a Next.js project. The change upgrades the version of the `actions/upload-pages-artifact` action from `v2` to `v3`.