### PR TITLE
[release]: update deployment action workflow

### DIFF
--- a/.github/workflows/next-js.yml
+++ b/.github/workflows/next-js.yml
@@ -77,7 +77,7 @@ jobs:
             - name: Static HTML export with Next.js
               run: ${{ steps.detect-package-manager.outputs.runner }} next export
             - name: Upload artifact
-              uses: actions/upload-pages-artifact@v2
+              uses: actions/upload-pages-artifact@v3
               with:
                   path: ./out
 


### PR DESCRIPTION
This pull request updates the Next.js GitHub Actions workflow to use the latest version of the `actions/upload-pages-artifact` action.

### Workflow update:

* [`.github/workflows/next-js.yml`](diffhunk://#diff-288833ba8c4f2652456f6ea798f1863b0df0f01ad7e7e5ff0a73d48265154bdeL80-R80): Upgraded the `actions/upload-pages-artifact` action from version `v2` to version `v3` to ensure compatibility and access to the latest features.