### PR TITLE
feat: update me section copy and footer

### DIFF
--- a/src/common/constants/site-content.ts
+++ b/src/common/constants/site-content.ts
@@ -13,8 +13,8 @@ export const SITE_CONTENT = {
         subTitle: `I'm Pongpanot, a software engineer. Interested in learning more about me? Let’s follow the sign.`,
     },
     me: {
-        title: 'me? Always coding.',
-        description: `Hello again! I’m Pongpanot, a software engineer specializing in frontend and mobile development, based in Chiang Mai. Focused on creating digital experiences that seamlessly blend visual appeal and high functionality, from the initial concept all the way through to launch.`,
+        title: 'Before AI, there was me.',
+        description: `I'm Pongpanot, a frontend engineer in Chiang Mai specializing in React and React Native. Now imagine what I'm capable of with AI in my hands.`,
     },
     journey: {
         title: 'Previous stops on my journey.',
@@ -214,5 +214,5 @@ export const SITE_CONTENT = {
             description: `Maybe I can help you, \n Let's join forces and create something epic.`,
         },
     },
-    footer: `Designed & Developed by ${TITLE} ${currentYear}`,
+    footer: `Crafted with Mojo and Gin — pongpanott`,
 };

--- a/src/container/home-page/sections/me-section/index.tsx
+++ b/src/container/home-page/sections/me-section/index.tsx
@@ -25,7 +25,7 @@ const MeSection = forwardRef<HTMLDivElement>((_, ref) => {
                         )}
                     />
                     <div>
-                        <h2 className="mb-[18px] md:mb-5 lg:mb-6">{SITE_CONTENT.me.title}</h2>
+                        <h2 className="mb-4">{SITE_CONTENT.me.title}</h2>
                         <p className="text-sm md:text-base max-w-[500px] mx-auto md:max-w-none">
                             {SITE_CONTENT.me.description}
                         </p>


### PR DESCRIPTION
This pull request updates the site content and refines the presentation of the "Me" section. The most important changes include rewording the personal introduction, updating the site footer, and adjusting the section's heading style.

**Content updates:**

* The `SITE_CONTENT.me.title` and `SITE_CONTENT.me.description` have been rewritten to emphasize AI skills and focus on frontend engineering with React and React Native.
* The site footer text in `SITE_CONTENT.footer` has been updated to "Crafted with Mojo and Gin — pongpanott" for a more personalized touch.

**UI adjustments:**

* The margin-bottom class for the "Me" section heading (`h2`) has been simplified from responsive values to a single `mb-4` class for consistency.